### PR TITLE
Show response update

### DIFF
--- a/lib/krill/show_response.rb
+++ b/lib/krill/show_response.rb
@@ -49,16 +49,6 @@ module Krill
       return (target_input_cell[:type] == 'number' ? target_input_cell[:value].to_f : target_input_cell[:value])
     end
 
-    # Returns a list of the Upload objects created from files uploaded in the ShowBlock
-    #
-    # @param var [Symbol/String]  the key that was specified to store data under in the `upload` call
-    # @return [Array<Upload>]  list of the Upload objects corresponding to the given key, or nil if the key
-    #               doesn't correspond to a valid list of uploads
-    def get_upload_response var
-      return nil if !is_upload?(var)
-      return self[var.to_sym].map {|up_hash| Upload.find(up_hash[:id])} 
-    end
-
     # Returns a hash of user responses, each under the var name specified in the ShowBlock where 
     # the response was collected. Table responses are stored in this hash as a list in order of
     # the rows of the table.
@@ -101,6 +91,16 @@ module Krill
     # @return [Boolean]  true if the key corresponds to a list of upload objects
     def is_upload? var
       return self[var.to_sym].is_a?(Array) && self[var.to_sym].all? { |up_hash| up_hash.is_a?(Hash) && up_hash.has_key?(:name) && up_hash.has_key?(:name)}
+    end
+
+    # Returns a list of the Upload objects created from files uploaded in the ShowBlock
+    #
+    # @param var [Symbol/String]  the key that was specified to store data under in the `upload` call
+    # @return [Array<Upload>]  list of the Upload objects corresponding to the given key, or nil if the key
+    #               doesn't correspond to a valid list of uploads
+    def get_upload_response var
+      return nil if !is_upload?(var)
+      return self[var.to_sym].map {|up_hash| Upload.find(up_hash[:id])} 
     end
   end
   

--- a/spec/krill/show_response_spec.rb
+++ b/spec/krill/show_response_spec.rb
@@ -76,8 +76,8 @@ get_table_response when parameterized with an op or row" do
 		raise_error(TableCellUndefined) )
 	end
 
-	it "Retrieves uploaded files as an array with get_upload_response" do
-		expect(resp.get_upload_response(:ups)).to eq([Upload.find(1), Upload.find(2)])
+	it "Retrieves uploaded files as an array of Upload with get_response" do
+		expect(resp.get_response(:ups)).to eq([Upload.find(1), Upload.find(2)])
 	end
 
 	it "Returns nil when get_upload_response is attempted on a key that is not an upload response" do

--- a/spec/krill/show_response_spec.rb
+++ b/spec/krill/show_response_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe ShowResponse do
 			{key: "tblrespnskey", opid: 3075, row: 0, value: "2", type: "number"},
 			{key: "tblrespnskey", opid: 3076, row: 1, value: "1", type: "number"}, 
 		],
-		timestamp: 123456789, measured_concentration: 53.2
+		timestamp: 123456789,
+		measured_concentration: 53.2,
+		ups: [{id: 1, name: 'upname1'}, {id: 2, name: 'upname2'}]
 	})
 
 	it "is backwards compatible with the original hash" do expect(resp).to eq({
@@ -18,7 +20,9 @@ RSpec.describe ShowResponse do
 			{key: "tblrespnskey", opid: 3075, row: 0, value: "2", type: "number"},
 			{key: "tblrespnskey", opid: 3076, row: 1, value: "1", type: "number"},
 		],
-		timestamp: 123456789, measured_concentration: 53.2
+		timestamp: 123456789,
+		measured_concentration: 53.2
+		ups: [{id: 1, name: 'upname1'}, {id: 2, name: 'upname2'}]
 	})
 	end
 	
@@ -39,7 +43,7 @@ symbol, string, or integer" do
 
 	it "returns a ruby hash representing the data with responses" do
     	expect(resp.responses()).to (
-    	eq({measured_concentration: 53.2, tblrespnskey: [2, 1]}) )
+    	eq({measured_concentration: 53.2, tblrespnskey: [2, 1], ups: [Upload.find(1), Upload.find(2)]}) )
     end
 
     it "returns the timestamp of the showblock with timestamp()" do
@@ -70,6 +74,14 @@ get_table_response when parameterized with an op or row" do
 
 		expect{resp.get_table_response(:tblrespnskey, op: 3075, row: 0)}.to (
 		raise_error(TableCellUndefined) )
+	end
+
+	it "Retrieves uploaded files as an array with get_upload_response" do
+		expect(resp.get_upload_response(:ups)).to eq([Upload.find(1), Upload.find(2)])
+	end
+
+	it "Returns nil when get_upload_response is attempted on a key that is not an upload response" do
+		expect(resp.get_upload_response(:measured_concentration)).to eq(nil)
 	end
 
 	it "works with large and complex response hashes" do

--- a/spec/krill/show_response_spec.rb
+++ b/spec/krill/show_response_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ShowResponse do
 			{key: "tblrespnskey", opid: 3076, row: 1, value: "1", type: "number"},
 		],
 		timestamp: 123456789,
-		measured_concentration: 53.2
+		measured_concentration: 53.2,
 		ups: [{id: 1, name: 'upname1'}, {id: 2, name: 'upname2'}]
 	})
 	end

--- a/spec/krill/show_response_spec.rb
+++ b/spec/krill/show_response_spec.rb
@@ -80,10 +80,6 @@ get_table_response when parameterized with an op or row" do
 		expect(resp.get_response(:ups)).to eq([Upload.find(1), Upload.find(2)])
 	end
 
-	it "Returns nil when get_upload_response is attempted on a key that is not an upload response" do
-		expect(resp.get_upload_response(:measured_concentration)).to eq(nil)
-	end
-
 	it "works with large and complex response hashes" do
 		bigresp = ShowResponse.new({
 			table_inputs: [ 


### PR DESCRIPTION
- responses() and get_response() now format upload responses as lists of Upload objects, replacing the lists of hashes with id and name that the underlying hash uses to represent upload responses