### PR TITLE
Technician update

### DIFF
--- a/app/views/operations/_operation_list_short.html.erb
+++ b/app/views/operations/_operation_list_short.html.erb
@@ -7,9 +7,10 @@
 
       <tr>
         <th style="width: 12%">Id</th>
+        <th style="width: 14%">Status</th>
         <th style="width: 12%">Plan</th>
         <th style="width: 20%">User</th>
-        <th style="width: 46%">
+        <th style="width: 32%">
           <a href="#" ng-click="operations.show_uploads = false"  ng-if="operations.show_uploads">I/O</a>
           <span ng-if="!operations.show_uploads">I/O</span>
           &nbsp;
@@ -22,6 +23,8 @@
       <tr ng-repeat="op in operations">
 
         <td>{{op.id}}</td>
+
+        <td>{{op.status}}</td>
 
         <td>
           <a ng-repeat="plan in op.plans" 

--- a/app/views/technician/_show_block.html.erb
+++ b/app/views/technician/_show_block.html.erb
@@ -200,6 +200,25 @@
   <div class='content' layout-fill layout="row" layout-align="center center">
     <b>Thank you <a href="/users/{{job.user.id}}">{{job.user.name}}!</a></b>
   </div>
+
+  <br>
+
+  <% 
+    all_ops = Job.find(params["job_id"]).operations
+    errored_ops = all_ops.select { |_op| _op.status ==  'error' }
+    good_ops = all_ops - errored_ops
+  %>
+  <div class='content' layout-fill layout="row" layout-align="center center">
+    <%= good_ops.length %> of <%= all_ops.length %> operations in this job have been completed successfully
+  </div>
+
+
+  <% if errored_ops.any? %>
+    <div class='content' layout-fill layout="row" layout-align="center center">
+      <b><%= "Operation".pluralize(errored_ops.length)%> <%= errored_ops.map { |_op| _op.id }.to_sentence %> <%= errored_ops.length == 1 ? "has" : "have"%> failed</b>
+    </div>
+  <% end %>
+
   <hr>
 
   <md-content class='md-white user-op-stats'>
@@ -234,5 +253,9 @@
 <script type="text/ng-template" id="aborted">
   <div class='content'>
     <h2 class="md-display-2 title">This job was canceled</h2>
+  </div>
+
+  <div class='content content-aborted'>
+    <b>All operations errored – report to a lab manager for further instructions</b>
   </div>
 </script>


### PR DESCRIPTION
As per Sam's request, I have made some small changes to the technician view

- the operations list table on the sidebar now shows the status of each operation
- the slide shown when a protocol is aborted now instructs technician to report to a lab manager
- the slide shown when a protocol is completed now lists which operations of the job have errored, if any

This is a small update, but I am making a pull request out of it because, on this last change in particular, I think I have contradicted the existing code paradigm for the file.

`app/views/technician/_show_block.html.erb` is an erb file, but before I started modifying it, there was **no embedded ruby in the file**, only angular.  Being more comfortable with the ruby namespace of aquarium, I implemented the list of errored/done operations on the completion slide using a small amount of embedded ruby logic in this file.

Please review and let me know if I should factor out the embedded code from this file into somewhere else.

Here is a before/after comparison of the completion slide. (Other two updates not shown)
![old_completed_screen](https://user-images.githubusercontent.com/3107677/43343031-a394effe-9199-11e8-867a-89bedca28b06.png)
![new_complete_screen](https://user-images.githubusercontent.com/3107677/43343036-a6573a62-9199-11e8-8fca-654088816172.png)
