### PR TITLE
Manager retry improvement

### DIFF
--- a/app/assets/javascripts/ng-control/operations.js
+++ b/app/assets/javascripts/ng-control/operations.js
@@ -293,6 +293,10 @@
 
         aq.each(ops, op => {
           op.set_status("pending").then(op => {
+            for (var i = 0; i < op.outputs.length; i++) {
+              op.outputs[i].item.mark_as_deleted()
+              // .clear_item().save();
+            }            
             get_numbers().then(numbers => {
               $scope.numbers = numbers;
               $scope.select(operation_type, 'pending', ops);

--- a/app/assets/javascripts/ng-control/operations.js
+++ b/app/assets/javascripts/ng-control/operations.js
@@ -295,7 +295,7 @@
           op.set_status("pending").then(op => {
             for (var i = 0; i < op.outputs.length; i++) {
               op.outputs[i].item.mark_as_deleted()
-              // .clear_item().save();
+              op.outputs[i].clear_item().save();
             }            
             get_numbers().then(numbers => {
               $scope.numbers = numbers;


### PR DESCRIPTION
In addition to making the selected operations status set to error, the retry button on the manager page now also sets the output items of all the selected operations to be marked as deleted.

This is an urgent feature request by the lab managers, who have until now been tasked with manually marking every output item as deleted for operation batches that they retry.