### PR TITLE
Switch Part io to display as collection [r][c] on manager page

### DIFF
--- a/app/views/items/_template.html.erb
+++ b/app/views/items/_template.html.erb
@@ -15,7 +15,10 @@
       <a ng-click='item.modal=true'
          ng-init="item.modal=false"
          ng-attr-data-open-item-popup="{{item.id}}"
-         class="clickable">{{item.id}}</a>
+         class="clickable">
+          <span ng-if="!collection">{{item.id}}</span>
+          <span ng-if="collection">{{collection.id}} [{{row}},{{column}}]</span>
+       </a>
     </span>
 
     <div class='ng-modal item-modal' ng-if='item.modal'>


### PR DESCRIPTION
part popup links will display in manager as 'collectionid [r][c]' instead of the part id.