### PR TITLE
Update deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add \
     mariadb-dev \
     mysql-client \
     nodejs \
+    nodejs-npm \
     sqlite-dev \
     git 
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.10'
 
 # SQL adapter
-gem 'mysql2', '~> 0.3.17'
+gem 'mysql2', '~> 0.4.10'
 
 # Needed for rails 3.2 => 4.0 upgrade
 gem 'protected_attributes'


### PR DESCRIPTION
Made changes to Dockerfile and Gemfile.

- apparently npm is no longer packaged with the nodejs apk, so install it seperately
- update mysql2 to 0.4.10 and the issue Clay brought up no longer happens but I'm not exactly sure why. Is there any reason we might want to stay on 0.3.17?
