### PR TITLE
Add export and import of operation type test code

### DIFF
--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -15,7 +15,7 @@ class TestController < ApplicationController
 
     ActiveRecord::Base.transaction do
       begin
-        resp = load_test(code: operation_type.code('test').content)
+        resp = load_test(code: operation_type.test.content)
         if resp.nil?
           test = ProtocolTest.new(operation_type, current_user)
           resp = pre_test(test: test)

--- a/app/models/operation_type.rb
+++ b/app/models/operation_type.rb
@@ -94,6 +94,10 @@ class OperationType < ActiveRecord::Base
     code 'documentation'
   end
 
+  def test
+    code 'test'
+  end
+
   def schedule_aux(ops, user, group, opts = {})
 
     job = Job.new

--- a/app/planner/operation_type_export.rb
+++ b/app/planner/operation_type_export.rb
@@ -155,7 +155,9 @@ module OperationTypeExport
       ot.new_code('precondition', obj[:precondition], user)
       ot.new_code('cost_model', obj[:cost_model], user)
       ot.new_code('documentation', obj[:documentation], user)
-      ot.new_code('test', obj[:test], user)
+      test_content = ''
+      test_content = obj[:test] if obj[:test]
+      ot.new_code('test', test_content, user)
 
       if obj[:timing]
         puts 'Timing: ' + obj[:timing].inspect
@@ -200,7 +202,9 @@ module OperationTypeExport
       ot.new_code('precondition', obj[:precondition], user)
       ot.new_code('cost_model', obj[:cost_model], user)
       ot.new_code('documentation', obj[:documentation], user)
-      ot.new_code('test', obj[:test], user)
+      test_content = ''
+      test_content = obj[:test] if obj[:test]
+      ot.new_code('test', test_content, user)
 
       if obj[:timing]
         puts 'Timing: ' + obj[:timing].inspect

--- a/app/planner/operation_type_export.rb
+++ b/app/planner/operation_type_export.rb
@@ -70,7 +70,7 @@ module OperationTypeExport
         precondition: precondition ? precondition.content : '',
         cost_model: cost_model ? cost_model.content : '',
         documentation: documentation ? documentation.content : '',
-
+        test: test ? test.content : '',
         timing: timing ? timing.export : nil
 
       }
@@ -132,7 +132,7 @@ module OperationTypeExport
 
       obj = data[:operation_type]
 
-      ot = OperationType.new name: obj[:name], category: obj[:category], deployed: obj[:deployed], on_the_fly: obj[:on_the_fly]
+      ot = OperationType.new(name: obj[:name], category: obj[:category], deployed: obj[:deployed], on_the_fly: obj[:on_the_fly])
       ot.save
 
       raise "Could not save operation type '#{obj[:name]}': " + ot.errors.full_messages.join(', ') + "." unless ot.errors.empty?
@@ -151,10 +151,11 @@ module OperationTypeExport
         end
       end
 
-      ot.new_code 'protocol', obj[:protocol], user
-      ot.new_code 'precondition', obj[:precondition], user
-      ot.new_code 'cost_model', obj[:cost_model], user
-      ot.new_code 'documentation', obj[:documentation], user
+      ot.new_code('protocol', obj[:protocol], user)
+      ot.new_code('precondition', obj[:precondition], user)
+      ot.new_code('cost_model', obj[:cost_model], user)
+      ot.new_code('documentation', obj[:documentation], user)
+      ot.new_code('test', obj[:test], user)
 
       if obj[:timing]
         puts 'Timing: ' + obj[:timing].inspect
@@ -195,10 +196,11 @@ module OperationTypeExport
         end
       end
 
-      ot.new_code 'protocol', obj[:protocol], user
-      ot.new_code 'precondition', obj[:precondition], user
-      ot.new_code 'cost_model', obj[:cost_model], user
-      ot.new_code 'documentation', obj[:documentation], user
+      ot.new_code('protocol', obj[:protocol], user)
+      ot.new_code('precondition', obj[:precondition], user)
+      ot.new_code('cost_model', obj[:cost_model], user)
+      ot.new_code('documentation', obj[:documentation], user)
+      ot.new_code('test', obj[:test], user)
 
       if obj[:timing]
         puts 'Timing: ' + obj[:timing].inspect


### PR DESCRIPTION
This PR treats `OperationTest` test `Code` objects the same way that other `Code` objects are treated on export and import.