### PR TITLE
Added tzdata to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && apk add \
     nodejs-npm \
     openjdk8-jre \
     sqlite-dev \
+    tzdata \
     yarn
 
 RUN mkdir /aquarium


### PR DESCRIPTION
This adds the `tzdata` package to the initial set of support packages installed in the base image. 