### PR TITLE
Reformat Error Page for Groups page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -90,7 +90,7 @@ class GroupsController < ApplicationController
         format.html { redirect_to @group, notice: 'Group was successfully created.' }
         format.json { render json: @group, status: :created, location: @group }
       else
-        format.html { render action: 'new' }
+        format.html { render layout: 'aq2', action: 'new' }
         format.json { render json: @group.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,7 +52,7 @@ class UsersController < ApplicationController
         flash[:success] = "#{params[:user][:name]} has been assimilated."
         redirect_to @user
       else
-        render 'new'
+        render action: 'new'
       end
 
     else

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -13,17 +13,18 @@
         </ul>
       </div>
     <% end %>
-
+    
       <label>Name</label>
-      <%= f.text_field :name %>
+      <%= f.text_field :name, class: 'span10',   
+      placeholder: "Your group name", maxlength: 255, required: true %>
 
       <label>Description</label>
-      <%= f.text_field :description, class: 'span6' %>
+      <%= f.text_field :description, class: 'span10', 
+      placeholder: "Your group description", maxlength: 255%>
 
-      <br />
-
-        <%= f.submit "Save", class: 'md-button md-primary md-raised' %>
-        <%= link_to 'Back', groups_path, class: 'md-button md-primary md-raised' %>
+    <br/>
+    <%= f.submit "Save", class: 'md-button md-primary md-raised' %>
+    <%= link_to 'Back', groups_path, class: 'md-button md-primary md-raised' %>
 
 
 

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -4,7 +4,7 @@
 
     <% if @group.errors.any? %>
       <div id="error_explanation">
-        <h2><%= pluralize(@group.errors.count, "error") %> prohibited this group from being saved:</h2>
+        <h5><%= pluralize(@group.errors.count, "error") %> prohibited this group from being saved:</h5>
 
         <ul>
         <% @group.errors.full_messages.each do |msg| %>
@@ -15,18 +15,16 @@
     <% end %>
     
       <label>Name</label>
-      <%= f.text_field :name, class: 'span10',   
-      placeholder: "Your group name", maxlength: 255, required: true %>
+      <%= f.text_field :name, class: 'span8',   
+      placeholder: "Your group name"%>
 
       <label>Description</label>
-      <%= f.text_field :description, class: 'span10', 
-      placeholder: "Your group description", maxlength: 255%>
+      <%= f.text_field :description, class: 'span8', 
+      placeholder: "Your group description"%>
 
     <br/>
     <%= f.submit "Save", class: 'md-button md-primary md-raised' %>
     <%= link_to 'Back', groups_path, class: 'md-button md-primary md-raised' %>
-
-
 
   <% end %>
 

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -4,8 +4,9 @@
 
     <% if @group.errors.any? %>
       <div id="error_explanation">
-        <h5><%= pluralize(@group.errors.count, "error") %> prohibited this group from being saved:</h5>
-
+          <div class="alert alert-error">
+            The form contains <%= pluralize(@group.errors.count, "error") %>.
+          </div>
         <ul>
         <% @group.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,6 +1,10 @@
-<% provide(:title, 'New Group') %>
+<% provide(:title, 'Add New Group') %>
 
-<h1>Add New group</h1>
+<% content_for :class do %>groups<% end %>
 
-<%= render 'form' %>
+<%= content_for :controller do %>noCtrl<% end %>
+
+<%= content_for :main do %>
+    <%= render 'form' %>
+<% end %>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -5,16 +5,18 @@
       <%= render 'shared/error_messages' %>
 
       <%= f.label :name %>
-      <%= f.text_field :name %>
+      <%= f.text_field :name, class: 'span10' %>
 
       <%= f.label :login %>
-      <%= f.text_field :login, id: "new_login"  %>
+      <%= f.text_field :login, id: "new_login", class: 'span10'  %>
 
       <%= f.label :password %>
-      <%= f.password_field :password, id: "new_password"  %>
+      <%= f.password_field :password, id: "new_password", class: 'span10'  %>
 
       <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, id: "new_confirmation"%>
+      <%= f.password_field :password_confirmation, id: "new_confirmation", class: 'span10'%>
+      
+      <br/>
 
       <%= f.submit "Create account", class: 'md-button md-raised md-primary' %>
       <%= link_to 'Back', users_path, class: 'md-button md-raised md-primary' %>


### PR DESCRIPTION
Problem: 
When there is an error for user's input, the save button navigates user to the error page which do not have the same layout format with other pages of the AQ