### PR TITLE
Reformat Error Page for Budgets page

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -12,11 +12,13 @@ class BudgetsController < ApplicationController
   # GET /budgets
   # GET /budgets.json
   def index
-    @budgets = Budget.all
     @budget = Budget.new
 
     respond_to do |format|
-      format.html { render layout: 'aq2' } # index.html.erb
+      format.html do
+        @budgets, @alphaParams = Budget.alpha_paginate(params[:letter], {db_mode: true, db_field: "name"})
+        render layout: 'aq2' 
+      end
       format.json { render json: @budgets }
     end
   end

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -65,7 +65,7 @@ class BudgetsController < ApplicationController
         format.html { redirect_to @budget, notice: 'Budget was successfully created.' }
         format.json { render json: @budget, status: :created, location: @budget }
       else
-        format.html { render action: 'new' }
+        format.html { render layout: 'aq2', action: 'new' }
         format.json { render json: @budget.errors, status: :unprocessable_entity }
       end
     end

--- a/app/views/budgets/_form.html.erb
+++ b/app/views/budgets/_form.html.erb
@@ -1,9 +1,12 @@
+<div layout-padding flex=50>
+
 <%= form_for(@budget) do |f| %>
 
   <% if @budget.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(@budget.errors.count, "error") %> prohibited this budget from being saved:</h2>
-
+      <div class="alert alert-error">
+        The form contains <%= pluralize(@budget.errors.count, "error") %>.
+      </div>
       <ul>
       <% @budget.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
@@ -12,30 +15,20 @@
     </div>
   <% end %>
 
-  <div class="field">
     <%= f.label "Budget Number / short name" %>
-    <%= f.text_field :name %>
-  </div>
+    <%= f.text_field :name, placeholder: "Your budget number/name"%>
 
-  <div class="field">
     <%= f.label :description %>
-    <%= f.text_field :description %>
-  </div>
+    <%= f.text_field :description, placeholder: "Budget description" %>
 
-  <div class="field">
     <%= f.label "Contact" %>
-    <%= f.text_field :contact %>
-  </div>      
+    <%= f.text_field :contact, placeholder: "Contact name" %>
 
-  <div class="field">
     <%= f.label "Contact's email" %>
-    <%= f.text_field :email %>
-  </div>
+    <%= f.text_field :email, placeholder: "Contact email"%>
 
-  <div class="field">
     <%= f.label "Contact's phone" %>
-    <%= f.text_field :phone %>
-  </div>
+    <%= f.text_field :phone, placeholder: "Contact phone"%>
 
   <div class="actions">
     <br />
@@ -43,7 +36,10 @@
       <%= f.submit 'Save', class: 'md-button md-raised md-primary' %>
     <% else %>
       <%= f.submit 'New Budget', class: 'md-button md-raised md-primary' %>
+      <%= link_to 'Back', budgets_path, class: 'md-button md-raised md-primary' %>
     <% end %>
   </div>
        
 <% end %>
+
+</div>

--- a/app/views/budgets/edit.html.erb
+++ b/app/views/budgets/edit.html.erb
@@ -1,6 +1,10 @@
+<% provide(:title, "Budget #{@budget.id}") %>
+
 <%= content_for :controller do %>noCtrl<% end %>
 
-<% provide(:title, "Budget #{@budget.id}") %>
+<% content_for :specific_title do %><% end %>
+
+<% content_for :sidebar do %><% end %>
 
 <% content_for :main do %>
 

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -46,7 +46,9 @@
 
 <% content_for :main do %>
 
-    <table class='table'>
+  <%= alphabetical_paginate @alphaParams %>
+ 
+  <table class="table" id="pagination_table" style="table-layout: fixed, width: 100%">
       <tr>
         <th style="width: 10%">Name</th>
         <th style="width: 30%">Description</th>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -6,9 +6,9 @@
 
 <% content_for :sidebar do %>
   <div flex layout-padding>
-    <h3>Create Bugget</h3>
 
 <%= form_for(@budget) do |f| %>
+  <h3>Create Bugget</h3>
 
   <% if @budget.errors.any? %>
       <%= render 'form' %> 

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -6,8 +6,41 @@
 
 <% content_for :sidebar do %>
   <div flex layout-padding>
-    <br><br>
-    <%= render 'form' %>
+    <h3>Create Bugget</h3>
+
+<%= form_for(@budget) do |f| %>
+
+  <% if @budget.errors.any? %>
+      <%= render 'form' %> 
+  <% end %>
+
+  <%= f.label "Budget Number / short name" %>
+  <%= f.text_field :name, placeholder: "Your budget number/name"%>
+
+  <%= f.label :description %>
+  <%= f.text_field :description, placeholder: "Budget description" %>
+
+  <%= f.label "Contact" %>
+  <%= f.text_field :contact, placeholder: "Contact name" %>
+
+  <%= f.label "Contact's email" %>
+  <%= f.text_field :email, placeholder: "Contact email"%>
+
+  <%= f.label "Contact's phone" %>
+  <%= f.text_field :phone, placeholder: "Contact phone"%>
+
+  <div class="actions">
+    <br />
+    <% if @budget.id %>
+      <%= f.submit 'Save', class: 'md-button md-raised md-primary' %>
+    <% else %>
+      <%= f.submit 'New Budget', class: 'md-button md-raised md-primary' %>
+    <% end %>
+       
+<% end %>
+
+</div>
+
   </div>
 <% end %>
 

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -13,15 +13,13 @@
 
 <% content_for :main do %>
 
-  <div flex layout-padding>
-
     <table class='table'>
       <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Contact</th>  
-        <th>Users</th>      
-        <th></th>
+        <th style="width: 10%">Name</th>
+        <th style="width: 30%">Description</th>
+        <th style="width: 10%">Contact</th>  
+        <th style="width: 40%">Users</th>      
+        <th style="width: 5%"></th>
       </tr>
 
       <% @budgets.each do |budget| %>
@@ -35,12 +33,14 @@
               }.join(', ')
             %>
           </td>            
-          <td><%= link_to 'Edit', edit_budget_path(budget) %></td>
+          <td>
+            <%= link_to edit_budget_path(budget) do %>
+              <icon class='icon-pencil'></icon>
+            <% end %>
+          </td>
         </tr>
       <% end %>
 
     </table>
-
-  </div>
 
 <% end %>

--- a/app/views/budgets/new.html.erb
+++ b/app/views/budgets/new.html.erb
@@ -1,7 +1,12 @@
-<h1>Define New Budget</h1>
+<% provide(:title, 'Add New Budget') %>
 
-<br />
+<% content_for :class do %>budgets<% end %>
 
-<%= render 'form' %>
+<%= content_for :controller do %>noCtrl<% end %>
+
+<%= content_for :main do %>
+    <%= render 'form' %>
+<% end %>
+
 
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, 'Add New User') %>
 
-<% content_for :class do %>groups<% end %>
+<% content_for :class do %>users<% end %>
 
 <%= content_for :controller do %>noCtrl<% end %>
 


### PR DESCRIPTION
1/ When there is an error for user's input, the save button navigates user to the error page which do not have the same layout format with other pages of the AQ -> Fixed
2/ Added edit icons for edit actions in the budgets table -> be consistent with other pages.
3/ Updated the input form for create budget (added place holder, required validation,...)

 (still in progress)