### PR TITLE
Show methods take arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,6 @@ ui/node_modules
 # ignore vscode settings
 .vscode
 
+coverage
+
 # please do not ignore Gemfile.lock !!!

--- a/lib/krill/show_block.rb
+++ b/lib/krill/show_block.rb
@@ -52,10 +52,11 @@ module Krill
     end
 
     # Put the string s in a smaller font on the page. Often called several times.
-    # @param str [String]
+    # If an array of strings is passed, then a note is made for each element of the array.
+    # @param str [String, Array<String>]
     # @return [void]
     def note(str)
-      @parts.push(note: str)
+      [*str].each { |s| @parts.push(note: s) }
     end
 
     # This is deprecated
@@ -75,17 +76,19 @@ module Krill
 
     # Put the string s on the page, with a clickable checkbox in front of it. The user will need
     # to click all checkboxes on a given page before the "OK" button is enabled.
-    # @param str [String]
+    # If an array of strings is passed, then a checkbox is made for each element of the array.
+    # @param str [String, Array<String>]
     # @return [void]
     def check(str)
-      @parts.push(check: str)
+      [*str].each { |s| @parts.push(check: s) }
     end
 
     # Put the string s on the page, with a bullet in front of it, as in a bullet list.
-    # @param str [String]
+    # If an array of strings is passed, then a bullet is made for each element of the array.
+    # @param str [String, Array<String>]
     # @return [void]
     def bullet(str)
-      @parts.push(bullet: str)
+      [*str].each { |s| @parts.push(bullet: s) }
     end
 
     # Display a table represented by the matrix t. The method takes a 2x2 list of either numbers,


### PR DESCRIPTION
Make show methods note, check, and bullet accept arrays of strings as an argument. Produces the same display as calling the method once on each element of the array.

This is useful for creating standard interfaces to things with differently complicated sets of instructions.